### PR TITLE
Updating import statements for changes to SpockBot.

### DIFF
--- a/minecraft_bot/src/mapnode.py
+++ b/minecraft_bot/src/mapnode.py
@@ -11,9 +11,8 @@ import rospy
 from minecraft_bot.msg import chunk_data_msg, chunk_bulk_msg, chunk_meta_msg, block_data_msg, map_block_msg
 from minecraft_bot.srv import get_block_srv, get_block_multi_srv
 
-from spock.utils import pl_announce, BoundBuffer
-from spock.mcmap import smpmap, mapdata
-from spock.mcp import mcdata
+from spockbot.mcp.bbuff import BoundBuffer
+from spockbot.plugins.tools import smpmap
 
 import time
 

--- a/minecraft_bot/src/test_mc_bot.py
+++ b/minecraft_bot/src/test_mc_bot.py
@@ -4,9 +4,9 @@
 # import rospy
 # from minecraft_bot.msg import movement_msg
 
-from spock import Client, PluginLoader
-from spock.plugins import DefaultPlugins
-from spock.plugins.helpers.entities import EntityPlugin
+from spockbot import Client
+from spockbot.plugins.loader import PluginLoader
+from spockbot.plugins import default_plugins
 
 # load custom plugins. I use capitalized names to indicate non-standard plugins
 from spockextras.plugins.helpers.MineAndPlace import MineAndPlacePlugin
@@ -22,7 +22,7 @@ from spockextras.plugins.helpers.SendEntityData import SendEntityDataPlugin
 
 # connect to localhost server
 settings = {'start': {'username': 'Bot',},'auth': {'authenticated': False,},}
-plugins = DefaultPlugins
+plugins = default_plugins
 
 plugins.append(('Messenger', MessengerPlugin))
 plugins.append(('SendMapData', SendMapDataPlugin))

--- a/spockextras/plugins/helpers/Messenger.py
+++ b/spockextras/plugins/helpers/Messenger.py
@@ -8,8 +8,8 @@ and ability to set message attributes from dictionary (with timestamp)
 
 import rospy
 
-from spock.utils import pl_announce
-from spock.mcp import mcdata
+from spockbot.plugins.base import pl_announce
+from spockbot.mcp import proto
 
 import logging
 logger = logging.getLogger('spock')
@@ -60,7 +60,7 @@ class MessengerPlugin:
         self.core = MessengerCore()
         ploader.provides('Messenger', self.core)
 
-        ploader.reg_event_handler((mcdata.PLAY_STATE, mcdata.SERVER_TO_CLIENT, 0x03), self.handleTimeUpdate)
+        ploader.reg_event_handler((proto.PLAY_STATE, proto.SERVER_TO_CLIENT, 0x03), self.handleTimeUpdate)
         ploader.reg_event_handler('disconnect', self.handleDisconnect)
         
 

--- a/spockextras/plugins/helpers/MineAndPlace.py
+++ b/spockextras/plugins/helpers/MineAndPlace.py
@@ -4,8 +4,7 @@ created by Bradley Sheneman
 simple plugin to provide block mine and place capability
 
 """
-from spock.mcp import mcdata
-from spock.utils import pl_announce
+from spockbot.plugins.base import pl_announce
 
 import logging
 logger = logging.getLogger('spock')

--- a/spockextras/plugins/helpers/NewMovement.py
+++ b/spockextras/plugins/helpers/NewMovement.py
@@ -15,8 +15,7 @@ import Queue
 import logging
 logger = logging.getLogger('spock')
 
-from spock.utils import pl_announce
-from spock.mcp import mcdata
+from spockbot.plugins.base import pl_announce
 
 # receives movement commands from ROS and sends update of current
 # position of client every 'client_tick'

--- a/spockextras/plugins/helpers/NewPhysics.py
+++ b/spockextras/plugins/helpers/NewPhysics.py
@@ -59,9 +59,10 @@ motions = { 1: PLAYER_WLK_ACC,
 PLAYER_JMP_ACC    = 0.45
 
 import math
-from spock.mcmap import mapdata
-from spock.utils import pl_announce, BoundingBox
-from spock.vector import Vector3
+from spockbot.mcdata import blocks
+from spockbot.plugins.base import pl_announce
+from spockbot.mcdata.utils import BoundingBox
+from spockbot.vector import Vector3
 
 import logging
 logger = logging.getLogger('spock')

--- a/spockextras/plugins/helpers/SendEntityData.py
+++ b/spockextras/plugins/helpers/SendEntityData.py
@@ -9,7 +9,8 @@ from minecraft_bot.msg import entity_movement_meta, entity_object_meta, entity_p
 
 
 
-from spock.utils import pl_announce, Info
+from spockbot.plugins.base import pl_announce
+from spockbot.mcdata.utils import Info
 
 import logging
 logger = logging.getLogger('spock')

--- a/spockextras/plugins/helpers/SendMapData.py
+++ b/spockextras/plugins/helpers/SendMapData.py
@@ -7,9 +7,8 @@ transfer significantly faster by delegating the work of unpacking individual blo
 ROS node. This does break some of the 'modularity', but performance will improve tremendously.
 """
 
-from spock.utils import pl_announce
-from spock.mcmap import smpmap, mapdata
-from spock.mcp import mcdata
+from spockbot.plugins.base import pl_announce
+from spockbot.mcp import proto
 
 class SendMapDataCore():
     
@@ -43,7 +42,7 @@ class SendMapDataPlugin:
         
         for i in range(len(packets)):
             ploader.reg_event_handler(
-                    (mcdata.PLAY_STATE, mcdata.SERVER_TO_CLIENT, packets[i]),
+                    (proto.PLAY_STATE, proto.SERVER_TO_CLIENT, packets[i]),
                     packet_handlers[i]
                     )
             ploader.reg_event_handler('disconnect', self.handleDisconnect)

--- a/spockextras/plugins/helpers/SpockControl.py
+++ b/spockextras/plugins/helpers/SpockControl.py
@@ -21,8 +21,7 @@ from minecraft_bot.msg import position_msg
 
 
 
-from spock.mcp import mcdata
-from spock.utils import pl_announce
+from spockbot.plugins.base import pl_announce
 
 import logging
 logger = logging.getLogger('spock')


### PR DESCRIPTION
The underlying spockbot code has many changes made to it that break the bot so it won't run.  This makes it so you can actually run it and join a server, however there is still another bug which causes it to drop from the server after some time when a particular server message is sent.  So the bot is now runnable, but only until it interacts with some particular kind of entity.
